### PR TITLE
Scope frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Now you can create pages with the `.markdoc` extension in `src/routes`:
 title: Hello from Markdoc
 ---
 
-# {% $title %}
+# {% $markdoc.frontmatter.title %}
 
 This is *super* cool.
 ```

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function render(source, config) {
 
 function addFrontmatter(ast, config) {
   const frontmatter = ast.attributes.frontmatter ? yaml.load(ast.attributes.frontmatter) : {}
-  const markdoc = Object.assign(config?.variables?.markdoc || {}, { frontmatter })
-  const variables = Object.assign(config?.variables || {}, { markdoc })
-	return Object.assign(config, { variables })
+  const markdoc = { ...(config?.variables?.markdoc || {}), frontmatter }
+  const variables = { ...(config?.variables || {}), markdoc }
+  return {...config, variables };
 }

--- a/index.js
+++ b/index.js
@@ -17,18 +17,14 @@ function isMarkdoc(path) {
 
 function render(source, config) {
   const ast = markdoc.parse(source)
-  const frontmatter = ast.attributes.frontmatter
-    ? yaml.load(ast.attributes.frontmatter)
-    : {};
-  const pageConfig = mergeVariables(config, frontmatter)
-  const content = markdoc.transform(ast, pageConfig)
-
+  const configWithFrontmatter = addFrontmatter(ast, config)
+  const content = markdoc.transform(ast, configWithFrontmatter)
   return markdoc.renderers.html(content)
 }
 
-function mergeVariables(config, frontmatter) {
-  const existing = config.variables || {}
-  const variables = {...existing, ...frontmatter}
-
-  return {...config, variables}
+function addFrontmatter(ast, config) {
+  const frontmatter = ast.attributes.frontmatter ? yaml.load(ast.attributes.frontmatter) : {}
+  const markdoc = Object.assign(config?.variables?.markdoc || {}, { frontmatter })
+  const variables = Object.assign(config?.variables || {}, { markdoc })
+	return Object.assign(config, { variables })
 }

--- a/test/preprocessor.test.js
+++ b/test/preprocessor.test.js
@@ -33,7 +33,7 @@ test('includes frontmatter in variables', () => {
 title: Hello World!
 ---
 
-# {% $title %}`
+# {% $markdoc.frontmatter.title %}`
   })
 
   expect(code).eq('<article><h1>Hello World!</h1></article>')
@@ -51,7 +51,7 @@ test('merges existing variables with frontmatter', () => {
 title: Best docs
 ---
 
-# {% $title %} in {% $currentYear %}`
+# {% $markdoc.frontmatter.title %} in {% $currentYear %}`
   })
 
   expect(code).eq('<article><h1>Best docs in 2022</h1></article>')
@@ -65,4 +65,18 @@ test("doesn't touch non-markdoc files", () => {
   })
 
   expect(output).toBeUndefined()
+})
+
+test("parses frontmatter", () => {
+  const process = preprocessor();
+  const {code} = process({
+    filename: 'example.markdoc',
+    content: `---
+title: What is Markdoc?
+---
+
+# {% $markdoc.frontmatter.title %} {% #overview %}`
+  })
+
+  expect(code).eq('<article><h1 id="overview">What is Markdoc? </h1></article>')
 })


### PR DESCRIPTION
The examples on https://markdoc.io/ surface frontmatter variables under `$markdoc.frontmatter.blah`, while here the preprocessor seems to make `$blah` a top level variable. This threw me a bit when I started copying examples across.

If you're happy with this change I think there's one snippet in the README that would need updating too.