### PR TITLE
Adopt svelte-kit package and add Markdoc.svelte

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /node_modules
+.DS_Store
+.svelte-kit/
+package/

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "./.svelte-kit/tsconfig.json",
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true
+	}
+}

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "svelte-markdoc",
   "version": "0.0.1",
   "description": "Markdoc preprocessor for Svelte",
-  "main": "index.js",
   "type": "module",
   "scripts": {
     "test": "vitest",
-    "coverage": "vitest run --coverage"
+    "coverage": "vitest run --coverage",
+    "package": "svelte-kit package"
   },
   "author": "Joshua Nussbaum",
   "homepage": "https://github.com/joshnuss/svelte-markdoc",
@@ -16,6 +16,9 @@
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
+    "@sveltejs/adapter-auto": "1.0.0-next.40",
+    "@sveltejs/kit": "1.0.0-next.328",
+    "svelte": "^3.48.0",
     "vitest": "^0.12.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
   "devDependencies": {
     "@sveltejs/adapter-auto": "1.0.0-next.40",
     "@sveltejs/kit": "1.0.0-next.328",
+    "@types/js-yaml": "^4.0.5",
     "svelte": "^3.48.0",
+    "svelte2tsx": "^0.5.10",
+    "typescript": "^4.6.4",
     "vitest": "^0.12.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "vitest",
     "coverage": "vitest run --coverage",
+    "dev": "svelte-kit dev",
     "package": "svelte-kit package"
   },
   "author": "Joshua Nussbaum",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,11 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@markdoc/markdoc': ^0.1.1
+  '@sveltejs/adapter-auto': 1.0.0-next.40
+  '@sveltejs/kit': 1.0.0-next.328
   js-yaml: ^4.1.0
+  svelte: ^3.48.0
   vitest: ^0.12.4
 
 dependencies:
@@ -10,14 +13,101 @@ dependencies:
   js-yaml: 4.1.0
 
 devDependencies:
+  '@sveltejs/adapter-auto': 1.0.0-next.40
+  '@sveltejs/kit': 1.0.0-next.328_svelte@3.48.0
+  svelte: 3.48.0
   vitest: 0.12.4
 
 packages:
+
+  /@iarna/toml/2.2.5:
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+    dev: true
 
   /@markdoc/markdoc/0.1.1:
     resolution: {integrity: sha512-ak7lacwM9fY99U+b9+IQ02qkcdc8Of0OPIWUdWNHW8zdmWam0fNRYoKWVR1B5OvdWDauYN3u0+ZbR9cds3oChw==}
     engines: {node: '>=14.7.0'}
     dev: false
+
+  /@rollup/pluginutils/4.2.1:
+    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    dev: true
+
+  /@sveltejs/adapter-auto/1.0.0-next.40:
+    resolution: {integrity: sha512-TT6YJUF3asJ/2RbviEpcDJQ/TixPcvmH0L2266fGNT7+KfAf9wbbVdegPWRODk2E2hTN0X+h5YS9l+lap+BK9w==}
+    dependencies:
+      '@sveltejs/adapter-cloudflare': 1.0.0-next.19
+      '@sveltejs/adapter-netlify': 1.0.0-next.56
+      '@sveltejs/adapter-vercel': 1.0.0-next.50
+    dev: true
+
+  /@sveltejs/adapter-cloudflare/1.0.0-next.19:
+    resolution: {integrity: sha512-LET3DUYpl+deoKhkWCzhHUT7iipYkgVkOcRIJX7qT4m23A+MAbzcAC3npgwEYSe9RokOSWMVBr3tVujeES5EeA==}
+    dependencies:
+      esbuild: 0.14.39
+      worktop: 0.8.0-next.13
+    dev: true
+
+  /@sveltejs/adapter-netlify/1.0.0-next.56:
+    resolution: {integrity: sha512-fM3aBHsr7syCGfIJcuB1mEoZwynqyOxVijvmyrd9OWHi6MP3bXSP+GhKDMtDpQRwejJJiwuZNTx2PUbV3uirvA==}
+    dependencies:
+      '@iarna/toml': 2.2.5
+      esbuild: 0.14.39
+      tiny-glob: 0.2.9
+    dev: true
+
+  /@sveltejs/adapter-vercel/1.0.0-next.50:
+    resolution: {integrity: sha512-yta0AkuWEr7qrm8LB34F4ZdCtMxj+cHD4huwrRYCgjv+PSJHLPwe7aH53+Mhrv6La0TgeyQ/f2lTyhBMXZXn9Q==}
+    dependencies:
+      esbuild: 0.14.39
+    dev: true
+
+  /@sveltejs/kit/1.0.0-next.328_svelte@3.48.0:
+    resolution: {integrity: sha512-L1RJ7wwLkOgo7aE+JiYppJEtVsSIpGPfgBZtjrS3J0avXVYUSTy+AfXbvjFJxTdk94uuCcTLUk/0vVODFm+Khg==}
+    engines: {node: '>=14.13'}
+    hasBin: true
+    peerDependencies:
+      svelte: ^3.44.0
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 1.0.0-next.44_svelte@3.48.0+vite@2.9.9
+      chokidar: 3.5.3
+      sade: 1.8.1
+      svelte: 3.48.0
+      vite: 2.9.9
+    transitivePeerDependencies:
+      - diff-match-patch
+      - less
+      - sass
+      - stylus
+      - supports-color
+    dev: true
+
+  /@sveltejs/vite-plugin-svelte/1.0.0-next.44_svelte@3.48.0+vite@2.9.9:
+    resolution: {integrity: sha512-n+sssEWbzykPS447FmnNyU5GxEhrBPDVd0lxNZnxRGz9P6651LjjwAnISKr3CKgT9v8IybP8VD0n2i5XzbqExg==}
+    engines: {node: ^14.13.1 || >= 16}
+    peerDependencies:
+      diff-match-patch: ^1.0.5
+      svelte: ^3.44.0
+      vite: ^2.9.0
+    peerDependenciesMeta:
+      diff-match-patch:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 4.2.1
+      debug: 4.3.4
+      deepmerge: 4.2.2
+      kleur: 4.1.4
+      magic-string: 0.26.2
+      svelte: 3.48.0
+      svelte-hmr: 0.14.11_svelte@3.48.0
+      vite: 2.9.9
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@types/chai-subset/1.3.3:
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
@@ -29,12 +119,32 @@ packages:
     resolution: {integrity: sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==}
     dev: true
 
+  /anymatch/3.1.2:
+    resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+    dev: true
+
   /argparse/2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: false
 
   /assertion-error/1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+    dev: true
+
+  /binary-extensions/2.2.0:
+    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /braces/3.0.2:
+    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+    engines: {node: '>=8'}
+    dependencies:
+      fill-range: 7.0.1
     dev: true
 
   /chai/4.3.6:
@@ -54,11 +164,43 @@ packages:
     resolution: {integrity: sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=}
     dev: true
 
+  /chokidar/3.5.3:
+    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.2
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /debug/4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: true
+
   /deep-eql/3.0.1:
     resolution: {integrity: sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==}
     engines: {node: '>=0.12'}
     dependencies:
       type-detect: 4.0.8
+    dev: true
+
+  /deepmerge/4.2.2:
+    resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /esbuild-android-64/0.14.39:
@@ -269,6 +411,17 @@ packages:
       esbuild-windows-arm64: 0.14.39
     dev: true
 
+  /estree-walker/2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
+
+  /fill-range/7.0.1:
+    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      to-regex-range: 5.0.1
+    dev: true
+
   /fsevents/2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -285,11 +438,33 @@ packages:
     resolution: {integrity: sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=}
     dev: true
 
+  /glob-parent/5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+    dependencies:
+      is-glob: 4.0.3
+    dev: true
+
+  /globalyzer/0.1.0:
+    resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
+    dev: true
+
+  /globrex/0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+    dev: true
+
   /has/1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
+    dev: true
+
+  /is-binary-path/2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+    dependencies:
+      binary-extensions: 2.2.0
     dev: true
 
   /is-core-module/2.9.0:
@@ -298,12 +473,34 @@ packages:
       has: 1.0.3
     dev: true
 
+  /is-extglob/2.1.1:
+    resolution: {integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-glob/4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extglob: 2.1.1
+    dev: true
+
+  /is-number/7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+    dev: true
+
   /js-yaml/4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
     dependencies:
       argparse: 2.0.1
     dev: false
+
+  /kleur/4.1.4:
+    resolution: {integrity: sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==}
+    engines: {node: '>=6'}
+    dev: true
 
   /local-pkg/0.4.1:
     resolution: {integrity: sha512-lL87ytIGP2FU5PWwNDo0w3WhIo2gopIAxPg9RxDYF7m4rr5ahuZxP22xnJHIvaLTe4Z9P6uKKY2UHiwyB4pcrw==}
@@ -316,10 +513,36 @@ packages:
       get-func-name: 2.0.0
     dev: true
 
+  /magic-string/0.26.2:
+    resolution: {integrity: sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==}
+    engines: {node: '>=12'}
+    dependencies:
+      sourcemap-codec: 1.4.8
+    dev: true
+
+  /mri/1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /mrmime/1.0.0:
+    resolution: {integrity: sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /ms/2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: true
+
   /nanoid/3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+    dev: true
+
+  /normalize-path/3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /path-parse/1.0.7:
@@ -334,6 +557,11 @@ packages:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
     dev: true
 
+  /picomatch/2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+    dev: true
+
   /postcss/8.4.13:
     resolution: {integrity: sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -341,6 +569,18 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
+
+  /readdirp/3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      picomatch: 2.3.1
+    dev: true
+
+  /regexparam/2.0.0:
+    resolution: {integrity: sha512-gJKwd2MVPWHAIFLsaYDZfyKzHNS4o7E/v8YmNf44vmeV2e4YfVoDToTOKTvE7ab68cRJ++kLuEXJBaEeJVt5ow==}
+    engines: {node: '>=8'}
     dev: true
 
   /resolve/1.22.0:
@@ -360,14 +600,46 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /sade/1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+    dependencies:
+      mri: 1.2.0
+    dev: true
+
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /sourcemap-codec/1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    dev: true
+
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+    dev: true
+
+  /svelte-hmr/0.14.11_svelte@3.48.0:
+    resolution: {integrity: sha512-R9CVfX6DXxW1Kn45Jtmx+yUe+sPhrbYSUp7TkzbW0jI5fVPn6lsNG9NEs5dFg5qRhFNAoVdRw5qQDLALNKhwbQ==}
+    engines: {node: ^12.20 || ^14.13.1 || >= 16}
+    peerDependencies:
+      svelte: '>=3.19.0'
+    dependencies:
+      svelte: 3.48.0
+    dev: true
+
+  /svelte/3.48.0:
+    resolution: {integrity: sha512-fN2YRm/bGumvjUpu6yI3BpvZnpIm9I6A7HR4oUNYd7ggYyIwSA/BX7DJ+UXXffLp6XNcUijyLvttbPVCYa/3xQ==}
+    engines: {node: '>= 8'}
+    dev: true
+
+  /tiny-glob/0.2.9:
+    resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
+    dependencies:
+      globalyzer: 0.1.0
+      globrex: 0.1.2
     dev: true
 
   /tinypool/0.1.3:
@@ -378,6 +650,13 @@ packages:
   /tinyspy/0.3.2:
     resolution: {integrity: sha512-2+40EP4D3sFYy42UkgkFFB+kiX2Tg3URG/lVvAZFfLxgGpnWl5qQJuBw1gaLttq8UOS+2p3C0WrhJnQigLTT2Q==}
     engines: {node: '>=14.0.0'}
+    dev: true
+
+  /to-regex-range/5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+    dependencies:
+      is-number: 7.0.0
     dev: true
 
   /type-detect/4.0.8:
@@ -439,4 +718,12 @@ packages:
       - less
       - sass
       - stylus
+    dev: true
+
+  /worktop/0.8.0-next.13:
+    resolution: {integrity: sha512-aLPWSneFtPJr3RAf841orF9GNlVdVkQd2Wj/BbcGHp3whBZoXx6dcwwClA9fezm7muNan4SuT+ZTyMWdoJSCAg==}
+    engines: {node: '>=12'}
+    dependencies:
+      mrmime: 1.0.0
+      regexparam: 2.0.0
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,8 +4,11 @@ specifiers:
   '@markdoc/markdoc': ^0.1.1
   '@sveltejs/adapter-auto': 1.0.0-next.40
   '@sveltejs/kit': 1.0.0-next.328
+  '@types/js-yaml': ^4.0.5
   js-yaml: ^4.1.0
   svelte: ^3.48.0
+  svelte2tsx: ^0.5.10
+  typescript: ^4.6.4
   vitest: ^0.12.4
 
 dependencies:
@@ -15,7 +18,10 @@ dependencies:
 devDependencies:
   '@sveltejs/adapter-auto': 1.0.0-next.40
   '@sveltejs/kit': 1.0.0-next.328_svelte@3.48.0
+  '@types/js-yaml': 4.0.5
   svelte: 3.48.0
+  svelte2tsx: 0.5.10_wwvk7nlptlrqo2czohjtk6eiqm
+  typescript: 4.6.4
   vitest: 0.12.4
 
 packages:
@@ -119,6 +125,10 @@ packages:
     resolution: {integrity: sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==}
     dev: true
 
+  /@types/js-yaml/4.0.5:
+    resolution: {integrity: sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==}
+    dev: true
+
   /anymatch/3.1.2:
     resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}
     engines: {node: '>= 8'}
@@ -189,6 +199,10 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: true
+
+  /dedent-js/1.0.1:
+    resolution: {integrity: sha1-vuX7fJ5yfYXf+iRZDRDsGrElUwU=}
     dev: true
 
   /deep-eql/3.0.1:
@@ -513,6 +527,12 @@ packages:
       get-func-name: 2.0.0
     dev: true
 
+  /lower-case/2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+    dependencies:
+      tslib: 2.4.0
+    dev: true
+
   /magic-string/0.26.2:
     resolution: {integrity: sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==}
     engines: {node: '>=12'}
@@ -540,9 +560,23 @@ packages:
     hasBin: true
     dev: true
 
+  /no-case/3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.4.0
+    dev: true
+
   /normalize-path/3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /pascal-case/3.1.2:
+    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.4.0
     dev: true
 
   /path-parse/1.0.7:
@@ -635,6 +669,18 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
+  /svelte2tsx/0.5.10_wwvk7nlptlrqo2czohjtk6eiqm:
+    resolution: {integrity: sha512-nokQ0HTTWMcNX6tLrDLiOmJCuqjKZU9nCZ6/mVuCL3nusXdbp+9nv69VG2pCy7uQC66kV4Ls+j0WfvvJuGVnkg==}
+    peerDependencies:
+      svelte: ^3.24
+      typescript: ^4.1.2
+    dependencies:
+      dedent-js: 1.0.1
+      pascal-case: 3.1.2
+      svelte: 3.48.0
+      typescript: 4.6.4
+    dev: true
+
   /tiny-glob/0.2.9:
     resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
     dependencies:
@@ -659,9 +705,19 @@ packages:
       is-number: 7.0.0
     dev: true
 
+  /tslib/2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+    dev: true
+
   /type-detect/4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
+    dev: true
+
+  /typescript/4.6.4:
+    resolution: {integrity: sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
     dev: true
 
   /vite/2.9.9:

--- a/src/app.html
+++ b/src/app.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%svelte.head%
+	</head>
+	<body>
+		<div>%svelte.body%</div>
+	</body>
+</html>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,0 +1,1 @@
+export { default as default } from './renderer/Markdoc.svelte'

--- a/src/lib/preprocess.js
+++ b/src/lib/preprocess.js
@@ -1,5 +1,5 @@
 import markdoc from '@markdoc/markdoc'
-import yaml from 'js-yaml'
+import { addFrontmatter } from './utils.js'
 
 export default function preprocessMarkdoc(config={}) {
   return (input) => {
@@ -20,11 +20,4 @@ function render(source, config) {
   const configWithFrontmatter = addFrontmatter(ast, config)
   const content = markdoc.transform(ast, configWithFrontmatter)
   return markdoc.renderers.html(content)
-}
-
-function addFrontmatter(ast, config) {
-  const frontmatter = ast.attributes.frontmatter ? yaml.load(ast.attributes.frontmatter) : {}
-  const markdoc = { ...(config?.variables?.markdoc || {}), frontmatter }
-  const variables = { ...(config?.variables || {}), markdoc }
-  return {...config, variables };
 }

--- a/src/lib/preprocess.js
+++ b/src/lib/preprocess.js
@@ -2,6 +2,7 @@ import markdoc from '@markdoc/markdoc'
 import { addFrontmatter } from './utils.js'
 
 export default function preprocessMarkdoc(config={}) {
+  /** @param {{ filename: string, content: string }} input */
   return (input) => {
     if (isMarkdoc(input.filename)) {
       return {
@@ -11,10 +12,19 @@ export default function preprocessMarkdoc(config={}) {
   }
 }
 
+/**
+ * @param {string} path 
+ * @returns boolean
+ */
 function isMarkdoc(path) {
   return /\.markdoc$/.test(path)
 }
 
+/**
+ * @param {string} source 
+ * @param {import("@markdoc/markdoc").Config} config 
+ * @returns string
+ */
 function render(source, config) {
   const ast = markdoc.parse(source)
   const configWithFrontmatter = addFrontmatter(ast, config)

--- a/src/lib/renderer/Markdoc.svelte
+++ b/src/lib/renderer/Markdoc.svelte
@@ -7,9 +7,9 @@
   import Tags from "./Tags.svelte"
   import { addFrontmatter } from "../utils.js"
 
-  const ast = Markdoc.parse(doc)
-  const configWithFrontmatter = addFrontmatter(ast, config)
-  const content = Markdoc.transform(ast, configWithFrontmatter)
+  $: ast = Markdoc.parse(doc)
+  $: configWithFrontmatter = addFrontmatter(ast, config)
+  $: content = Markdoc.transform(ast, configWithFrontmatter)
 </script>
 
 <Tags children={content.children} {components}></Tags>

--- a/src/lib/renderer/Markdoc.svelte
+++ b/src/lib/renderer/Markdoc.svelte
@@ -1,0 +1,15 @@
+<script>
+  export let doc = ""
+  export let config = {}
+  export let components = new Map
+
+  import Markdoc from "@markdoc/markdoc"
+  import Tags from "./Tags.svelte"
+  import { addFrontmatter } from "../utils.js"
+
+  const ast = Markdoc.parse(doc)
+  const configWithFrontmatter = addFrontmatter(ast, config)
+  const content = Markdoc.transform(ast, configWithFrontmatter)
+</script>
+
+<Tags children={content.children} {components}></Tags>

--- a/src/lib/renderer/Markdoc.svelte
+++ b/src/lib/renderer/Markdoc.svelte
@@ -10,6 +10,7 @@
   $: ast = Markdoc.parse(doc)
   $: configWithFrontmatter = addFrontmatter(ast, config)
   $: content = Markdoc.transform(ast, configWithFrontmatter)
+  $: children = (content && typeof content != "string" && content.children) || []
 </script>
 
-<Tags children={content.children} {components}></Tags>
+<Tags {children} {components}></Tags>

--- a/src/lib/renderer/Tags.svelte
+++ b/src/lib/renderer/Tags.svelte
@@ -1,0 +1,20 @@
+<script>
+  export let children = []
+  export let components = new Map
+  // todo: throw error if tag is neither an html element or a component?
+</script>
+
+{#each children as child}
+  {#if typeof child === "string"}{child}{/if}
+  {#if child.children}
+    {#if components.has(child.name)}
+      <svelte:component this={components.get(child.name)} {...child.attributes}>
+        <svelte:self children={child.children} />
+      </svelte:component>
+    {:else}
+      <svelte:element this={child.name} {...child.attributes}>
+        <svelte:self children={child.children} />
+      </svelte:element>
+    {/if}
+  {/if}
+{/each}

--- a/src/lib/renderer/Tags.svelte
+++ b/src/lib/renderer/Tags.svelte
@@ -1,4 +1,5 @@
 <script>
+  /** @type {import("@markdoc/markdoc").RenderableTreeNode[]}*/
   export let children = []
   export let components = new Map
   // todo: throw error if tag is neither an html element or a component?
@@ -6,7 +7,7 @@
 
 {#each children as child}
   {#if typeof child === "string"}{child}{/if}
-  {#if child.children}
+  {#if child && typeof child != "string" && child.children}
     {#if components.has(child.name)}
       <svelte:component this={components.get(child.name)} {...child.attributes}>
         <svelte:self children={child.children} />

--- a/src/lib/site/Callout.svelte
+++ b/src/lib/site/Callout.svelte
@@ -1,0 +1,24 @@
+<script>
+  /** @type {"check"} */
+	export let type;
+
+  if (type != "check") console.warn("Callout.svelte only supports type: check");
+</script>
+
+<div class="callout {type}">
+  <slot></slot>
+</div>
+
+<style>
+  .callout {
+    display: inline-flex;
+    line-height: 20px;
+    padding: 12px 20px;
+    border: 1px solid #dce6e9;
+    border-radius: 4px;
+  }
+
+  .check {
+    background-color: #f6f9fc;
+  }
+</style>

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -2,7 +2,7 @@ import yaml from 'js-yaml'
 
 export function addFrontmatter(ast, config) {
   const frontmatter = ast.attributes.frontmatter ? yaml.load(ast.attributes.frontmatter) : {}
-  const markdoc = Object.assign(config?.variables?.markdoc || {}, { frontmatter })
-  const variables = Object.assign(config?.variables || {}, { markdoc })
-	return Object.assign(config, { variables })
+  const markdoc = { ...(config?.variables?.markdoc || {}), frontmatter }
+  const variables = { ...(config?.variables || {}), markdoc }
+  return {...config, variables };
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,7 +1,12 @@
 import yaml from 'js-yaml'
 
+/**
+ * @param {import("@markdoc/markdoc").Node} ast 
+ * @param {import("@markdoc/markdoc").Config} config 
+ * @returns 
+ */
 export function addFrontmatter(ast, config) {
-  const frontmatter = ast.attributes.frontmatter ? yaml.load(ast.attributes.frontmatter) : {}
+  const frontmatter = yaml.load(ast?.attributes?.frontmatter || "")
   const markdoc = { ...(config?.variables?.markdoc || {}), frontmatter }
   const variables = { ...(config?.variables || {}), markdoc }
   return {...config, variables };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,8 @@
+import yaml from 'js-yaml'
+
+export function addFrontmatter(ast, config) {
+  const frontmatter = ast.attributes.frontmatter ? yaml.load(ast.attributes.frontmatter) : {}
+  const markdoc = Object.assign(config?.variables?.markdoc || {}, { frontmatter })
+  const variables = Object.assign(config?.variables || {}, { markdoc })
+	return Object.assign(config, { variables })
+}

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,0 +1,48 @@
+<script>
+	import Markdoc from "$lib/index.js";
+	import Callout from "$lib/site/Callout.svelte";
+
+	const doc = `---
+title: What is Markdoc?
+---
+
+# {% $markdoc.frontmatter.title %} {% #overview %}
+
+Markdoc is a Markdown-based syntax and toolchain for creating custom documentation sites. Stripe created Markdoc to power [our public docs](http://stripe.com/docs).
+
+{% callout type="check" %}
+Markdoc is open-source—check out its [source](http://github.com/markdoc/markdoc) to see how it works.
+{% /callout %}
+
+## How is Markdoc different?
+
+Markdoc uses a fully declarative approach to composition and flow control, where other solutions… [Read more](/docs/overview).
+
+## Next steps
+- [Install Markdoc](/docs/getting-started)
+- [Explore the syntax](/docs/syntax)
+`;
+
+	const config = {
+		tags: {
+			callout: {
+				render: "Callout",
+				description: "Display the enclosed content in a callout box",
+				children: ["paragraph", "tag", "list"],
+				attributes: {
+					type: {
+						type: String,
+						default: "note",
+						matches: ["check", "error", "note", "warning"]
+					}
+				}
+			}
+		}
+	};
+
+  const components = new Map([
+    ["Callout", Callout]
+  ])
+</script>
+
+<Markdoc {doc} {config} {components} />

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -6,8 +6,7 @@ const config = {
 		adapter: adapter(),
     package: {
       files: path => !path.match(/site/),
-      exports: path => path.match(/package.json$|index.js$|preprocess.js$/),
-      emitTypes: false // todo
+      exports: path => path.match(/package.json$|index.js$|preprocess.js$/)
     }
 	}
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -5,6 +5,7 @@ const config = {
 	kit: {
 		adapter: adapter(),
     package: {
+      files: path => !path.match(/site/),
       exports: path => path.match(/package.json$|index.js$|preprocess.js$/),
       emitTypes: false // todo
     }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,0 +1,14 @@
+import adapter from '@sveltejs/adapter-auto'
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {
+		adapter: adapter(),
+    package: {
+      exports: path => path.match(/package.json$|index.js$|preprocess.js$/),
+      emitTypes: false // todo
+    }
+	}
+}
+
+export default config

--- a/test/preprocess.test.js
+++ b/test/preprocess.test.js
@@ -1,8 +1,8 @@
 import { assert, expect, test } from 'vitest'
-import preprocessor from '../index.js'
+import preprocessMarkdoc from '../src/lib/preprocess.js'
 
 test('processes .markdoc file', () => {
-  const process = preprocessor()
+  const process = preprocessMarkdoc()
   const {code} = process({
     filename: 'example.markdoc',
     content: '# Hello World'
@@ -12,7 +12,7 @@ test('processes .markdoc file', () => {
 })
 
 test('includes config', () => {
-  const process = preprocessor({
+  const process = preprocessMarkdoc({
     variables: {
       title: "Hello World!"
     }
@@ -26,7 +26,7 @@ test('includes config', () => {
 })
 
 test('includes frontmatter in variables', () => {
-  const process = preprocessor({})
+  const process = preprocessMarkdoc({})
   const {code} = process({
     filename: 'example.markdoc',
     content: `---
@@ -40,7 +40,7 @@ title: Hello World!
 })
 
 test('merges existing variables with frontmatter', () => {
-  const process = preprocessor({
+  const process = preprocessMarkdoc({
     variables: {
       currentYear: "2022"
     }
@@ -58,7 +58,7 @@ title: Best docs
 })
 
 test("doesn't touch non-markdoc files", () => {
-  const process = preprocessor()
+  const process = preprocessMarkdoc()
   const output = process({
     filename: 'mc-hammer.svelte',
     content: "can't touch this"
@@ -68,7 +68,7 @@ test("doesn't touch non-markdoc files", () => {
 })
 
 test("parses frontmatter", () => {
-  const process = preprocessor();
+  const process = preprocessMarkdoc();
   const {code} = process({
     filename: 'example.markdoc',
     content: `---


### PR DESCRIPTION
This is a first attempt at adding `Markdoc.svelte` into the mix. I have rejigged the repo as per `svelte-kit package`, but if you can think of a cleaner way to bundle the component and the preprocessor then I'd be happy to abandon this approach. 

These things remain on the todo list:

- [ ] Updated README
- [ ] Tests?
- [ ] Types?